### PR TITLE
add id index

### DIFF
--- a/mysql/posts.sql
+++ b/mysql/posts.sql
@@ -5,5 +5,6 @@
   `imgdata` mediumblob NOT NULL,
   `body` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10012 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+  PRIMARY KEY (`id`),
+  KEY `id_idx` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=10062 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |


### PR DESCRIPTION
スロークエリログを見て、負荷の一番高いと思われる
`SELECT * FROM `posts` WHERE `id` = ？？`
に対応するためにindexはった。

`alter table posts add index id_idx(id);`

変更前
````
{"pass":true,"score":15383,"success":14464,"fail":0,"messages":[]}
````

````
{"pass":true,"score":15598,"success":14662,"fail":0,"messages":[]}
````

若干上がったが誤差かもしれないので、後々削除するかも。
