### PR TITLE
unable prepare statement

### DIFF
--- a/golang/app.go
+++ b/golang/app.go
@@ -815,7 +815,7 @@ func main() {
 	}
 
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local",
+		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local&interpolateParams=true",
 		user,
 		password,
 		host,

--- a/golang/restart_go.sh
+++ b/golang/restart_go.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+go build -o app app.go
+sudo systemctl restart isu-go


### PR DESCRIPTION
ADMINPREPAREの回数が多いので
プリペアドステートメントを無効にする。

````
{"pass":true,"score":15598,"success":14662,"fail":0,"messages":[]}
````

````
{"pass":true,"score":16077,"success":15102,"fail":0,"messages":[]} 
````

そこまで大きな変化はない。というかほぼ誤差。
かと思いきやもう一度ベンチ打つと結構変わる

`{"pass":true,"score":17310,"success":16249,"fail":0,"messages":[]}`