### PR TITLE
change digest func

### DIFF
--- a/golang/app.go
+++ b/golang/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	crand "crypto/rand"
+	"crypto/sha512"
 	"fmt"
 	"html/template"
 	"io"
@@ -9,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -117,14 +117,7 @@ func escapeshellarg(arg string) string {
 }
 
 func digest(src string) string {
-	// opensslのバージョンによっては (stdin)= というのがつくので取る
-	out, err := exec.Command("/bin/bash", "-c", `printf "%s" `+escapeshellarg(src)+` | openssl dgst -sha512 | sed 's/^.*= //'`).Output()
-	if err != nil {
-		log.Print(err)
-		return ""
-	}
-
-	return strings.TrimSuffix(string(out), "\n")
+	return fmt.Sprintf("%x", sha512.Sum512([]byte(src)))
 }
 
 func calculateSalt(accountName string) string {

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -14,4 +14,5 @@ require (
 require (
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/memcachier/mc v2.0.1+incompatible // indirect
+	golang.org/x/crypto v0.7.0 // indirect
 )

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -19,3 +19,5 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/memcachier/mc v2.0.1+incompatible h1:s8EDz0xrJLP8goitwZOoq1vA/sm0fPS4X3KAF0nyhWQ=
 github.com/memcachier/mc v2.0.1+incompatible/go.mod h1:7bkvFE61leUBvXz+yxsOnGBQSZpBSPIMUQSmmSHvuXc=
+golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
+golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=


### PR DESCRIPTION
外部コマンドを実行すると、アプリケーションとは別のプロセスを起動する必要があり、起動コスト＋メモリ消費をするため、ライブラリで代用。



`{"pass":true,"score":16077,"success":15102,"fail":0,"messages":[]} `
＝＞
`{"pass":true,"score":18106,"success":17014,"fail":0,"messages":[]}`