### PR TITLE
stream static file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node
 /php
 /ruby
+/public/image

--- a/golang/app.go
+++ b/golang/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -685,6 +686,14 @@ func getImage(w http.ResponseWriter, r *http.Request) {
 		ext == "gif" && post.Mime == "image/gif" {
 		w.Header().Set("Content-Type", post.Mime)
 		_, err := w.Write(post.Imgdata)
+		if err != nil {
+			log.Print(err)
+			return
+		}
+		// ファイルに書き出す
+		filename := "../public/image/" + pidStr + "." + ext
+		err = ioutil.WriteFile(filename, post.Imgdata, 0666)
+		os.Chmod(filename, 0666)
 		if err != nil {
 			log.Print(err)
 			return


### PR DESCRIPTION
静的ファイルをnginxで配信＋アップロード画像を静的ファイル化。

/etc/nginx/sites-available/isucon.conf
````
server {
  listen 80;

  client_max_body_size 10m;

  root /home/isucon/private_isu/webapp/public/;

  location ~ ^/(favicon\.ico|css/|js/|img/) {
    root /home/isucon/private_isu/webapp/public/;
    expires 1d;
  }

  location /image/ {
    root /home/isucon/private_isu/webapp/public/; expires 1d;
    try_files $uri @app;
  }

  location @app {
    internal;
    proxy_pass http://localhost:8080;
  }

  location / {
    proxy_set_header Host $host;
    proxy_pass http://127.0.0.1:8080;
  }
}

````


修正前は/image/*のSUMは180ほど
/css,/jsのSUMは4.0ほどあった。


修正後
````
+-------+--------+--------------------+-------+-------+-------+---------+
| COUNT | METHOD |        URI         |  MIN  |  AVG  |  MAX  |   SUM   |
+-------+--------+--------------------+-------+-------+-------+---------+
| 19381 | GET    | /image/*           | 0.000 | 0.001 | 0.176 | 18.136  |
| 1914  | GET    | /css/style.css     | 0.000 | 0.000 | 0.000 | 0.000   |
| 1914  | GET    | /js/timeago.min.js | 0.000 | 0.000 | 0.000 | 0.000   |
| 1914  | GET    | /favicon.ico       | 0.000 | 0.000 | 0.000 | 0.000   |
| 1914  | GET    | /js/main.js        | 0.000 | 0.000 | 0.000 | 0.000   |
| 971   | GET    | /                  | 0.048 | 0.379 | 0.740 | 368.144 |
````

