### PR TITLE
add index to posts

### DIFF
--- a/mysql/posts.sql
+++ b/mysql/posts.sql
@@ -6,5 +6,6 @@
   `body` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `id_idx` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10062 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+  KEY `id_idx` (`id`),
+  KEY `created_at_idx` (`created_at` DESC)
+) ENGINE=InnoDB AUTO_INCREMENT=13008 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |


### PR DESCRIPTION
````
mysql> explain SELECT p.id, p.user_id, p.body, p.mime, p.created_at FROM `posts` AS p JOIN `users` AS u ON (p.user_id=u.id) WHERE u.del_flg=0 ORDER BY p.created_at DESC LIMIT 20\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: p
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 10049
     filtered: 100.00
        Extra: Using filesort
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: u
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: isuconp.p.user_id
         rows: 1
     filtered: 10.00
        Extra: Using where
2 rows in set, 1 warning (0.01 sec)
````

スロークエリ1位のselect posts user を見てみると、using filesortが行われているので、created_atでindexを張る。

`alter table posts  add index created_at_idx(created_at DESC);`

````
--------------------------------------------------------------------------------+
| posts | CREATE TABLE `posts` (
  `id` int NOT NULL AUTO_INCREMENT,
  `user_id` int NOT NULL,
  `mime` varchar(64) NOT NULL,
  `imgdata` mediumblob NOT NULL,
  `body` text NOT NULL,
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`),
  KEY `id_idx` (`id`),
  KEY `created_at_idx` (`created_at` DESC)
) ENGINE=InnoDB AUTO_INCREMENT=13008 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
````


`{"pass":true,"score":62357,"success":59871,"fail":0,"messages":[]}`
=>
`{"pass":true,"score":89679,"success":85752,"fail":0,"messages":[]}`



