### PR TITLE
add index  use_id to coments

### DIFF
--- a/mysql/comments.sql
+++ b/mysql/comments.sql
@@ -5,5 +5,6 @@
   `comment` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `post_id_created_at_idx` (`post_id`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=100015 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+  KEY `post_id_created_at_idx` (`post_id`,`created_at`),
+  KEY `user_id_idx` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=103357 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |


### PR DESCRIPTION
````
# Rank Query ID                           Response time Calls  R/Call V/M 
# ==== ================================== ============= ====== ====== ====
#    1 0x396201721CD58410E070DA9421CA8C8D 85.6534 30.9% 148073 0.0006  0.00 SELECT users
#    2 0x624863D30DAC59FA16849282195BE09F 51.6490 18.6%  73900 0.0007  0.00 SELECT comments
#    3 0x422390B42D4DD86C7539A5F45EB76A80 49.6719 17.9%  75954 0.0007  0.00 SELECT comments
#    4 0xCDEB1AFF2AE2BE51B2ED5CF03D4E749F 33.8552 12.2%    291 0.1163  0.04 SELECT comments
````


4番目のクエリのSELECT commentsのR/CALLが他のものに比べて大きいのでuser_idにindexを張った。

````
{"pass":true,"score":99307,"success":100297,"fail":405,"messages":["ステータスコードが正しくありません: expected 200, got 500 (POST /)","ステータスコードが正しくありません: expected 422, got 500 (POST /)","リクエストがタイムアウトしました (POST /comment)","リクエストがタイムアウトしました (POST /register)"]}
````

なぜかcommentsにindexを追加しただけで、リクエストがタイムアウトするようになった。
